### PR TITLE
Fix spec for join queries

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,10 +18,8 @@ RSpec.describe User, type: :model do
       expect(u2.profile.location).to eq 'Tokyo'
       expect(u2.profile.working_histories.size).to eq 2
 
-      u3 = User.eager_load(profile: :working_histories).to_a.last
-      expect(u3.profile).to be_present
-      expect(u3.profile.location).to eq 'Tokyo'
-      expect(u3.profile.working_histories.size).to eq 2
+      expect { User.eager_load(profile: :working_histories).to_a }.to raise_error(ActiveRecord::StatementInvalid)
+      expect { User.includes(:profile).where(profile: { location: 'Tokyo' }).to_a }.to raise_error(ActiveRecord::StatementInvalid)
     end
   end
 end


### PR DESCRIPTION
## WHY
「別DBのtableをJOINできない」が正しい挙動のはず

## WHAT
↑こうなるようにRSpecを修正